### PR TITLE
Update Gecko SDK, ARM toolchain and docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,12 +2,60 @@
 Compiling applications for the node platform requires several components, their
 installation is covered here.
 
+# MCU SDK and commander tool
+The SiLabs Gecko SDKs can be obtained by installing Simplicity Studio. Due to
+SiLabs licensing terms, it is not possible to redistribute the files with the
+project and it is necessary to download and install Simplicity Studio and the
+Gecko SDK. This requires registration with SiLabs.
+
+https://www.silabs.com/products/development-tools/software/simplicity-studio
+
+Installing Simplicity Studio:
+- Register with SiLabs and download `SimplicityStudio-5.tgz`
+- Unpack Simplicity Studio\
+  `tar xzvf SimplicityStudio-5.tgz -C ~`
+- Run Simplicity Studio setup\
+  `./setup.sh`
+- Start Simplicity Studio\
+  `./studio`
+- Read and accept License agreements
+- Log in with your SiLabs account
+- Click `Help->Update Software`\
+  (wait for update process to complete)
+- Click `Install by Device`
+- Choose the `SLWSTK6000B` Mighty Gecko Kit and click Next **twice**
+- Make sure at least `Flex SDK 3.2.0.0` is selected and click Next\
+  (It should be ok to use newer versions as well, though the SILABS_SDKDIR path may need adjustment)
+- Accept licenses, click Finish, wait for completion and exit
+- Add the path to commander to path - edit `~/.profile` and add:\
+  `export PATH=$PATH:~/SimplicityStudio_v5/developer/adapter_packs/commander`
+
+Makefiles require that the SILABS_SDKDIR variable point to the
+SimplicityStudio_v5/developer/sdks/gecko_sdk_suite/v3.2 directory, so take
+note of where SimplicityStudio_v5 ended up, if you followed the steps above,
+then it should be stored at /home/user/SimplicityStudio_v5, which is the default
+for SILABS_SDKDIR in the Makefiles.
+
+
 # Compiler and toolchain
-Currently the platform uses the ARM toolchain provided by Arm Ltd, which can be
-obtained from
+
+## Leveraging Simplicity Studio 5
+At the time of writing, Simplicity Studio 5 also comes with the latest ARM toolchain provided by Arm Ltd (version 10-2020-q4-major).
+
+If you followed the steps above and your Simplicity Studio installation ended up at `/home/user/SimplicityStudio_v5`, you can simply:
+
+- edit `~/.profile` and add:\
+  `export PATH=$PATH:~/SimplicityStudio_v5/developer/toolchains/gnu_arm/10.2_2020q4/bin`
+- Refresh the environment and check version:\
+  `source ~/.profile`\
+  `arm-none-eabi-gcc -v`
+
+
+## Directly form ARM Website
+Alternatively, the toolchain can be obtained from
 [ARM toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
 
-"Version 8-2019-q3-update Linux 64-bit" is known to be a good working version.
+Version `8-2019-q3-update (Linux 64-bit)` is known to be a good working version, but these same steps apply if you prefer to use version `10-2020-q4-major`.
 
 The ARM toolchain can be compiled from source, but installing the binary version
 is easy and only requires that the *bin* directory of the toolchain be added
@@ -18,48 +66,11 @@ to the $PATH.
 - Add to path - edit `~/.profile` and add:\
   `export PATH=$PATH:/opt/gcc-arm-none-eabi-8-2019-q3-update/bin`
 - Refresh the environment and check version:\
-  `source ~/.profile`
+  `source ~/.profile`\
   `arm-none-eabi-gcc -v`
 
-Alternatively it is possible to use the compiler from Simplicity Studio or
-the one provided by you Linux distribution, but do note that the compiler in
-Ubuntu 18.04 failed to generate working code (a linker bug) and the one in
-Simplicity Studio is relatively old and is not actively tested with the node
-platform.
+It is also possible to use the compiler provided by your Linux distribution, but do note that the compiler in Ubuntu 18.04 failed to generate working code (a linker bug) and the one that came with Simplicity Studio 4 is relatively old and is not actively tested with the node platform.
 
-# MCU SDK and commander tool
-The SiLabs Gecko SDKs can be obtained by installing Simplicity Studio. Due to
-SiLabs licensing terms, it is not possible to redistribute the files with the
-project and it is necessary to download and install Simplicity Studio and the
-Gecko SDK. This requires registration with SiLabs.
-
-https://www.silabs.com/products/development-tools/software/simplicity-studio
-
-Installing Simplicity Studio:
-- Register with SiLabs and download `SimplicityStudio-v4.tgz`
-- Unpack Simplicity Studio\
-  `tar xzvf SimplicityStudio-v4.tgz -C ~`
-- Run Simplicity Studio setup\
-  `./setup.sh`
-- Start Simplicity Studio\
-  `./run_studio.sh`
-- Read and accept License agreements
-- Log in with your SiLabs account
-- Click `Help->Update Software`\
-  (wait for update process to complete)
-- Click `Install by Device`
-- Choose the `SLWSTK6000B` Mighty Gecko Kit and click Next **twice**
-- Make sure at least `Flex SDK 2.7.1.0` is selected and click Next\
-  (It should be ok to use newer versions as well, though the SILABS_SDKDIR path may need adjustment)
-- Accept licenses, click Finish, wait for completion and exit
-- Add the path to commander to path - edit `~/.profile` and add:\
-  `export PATH=$PATH:~/SimplicityStudio_v4/developer/adapter_packs/commander`
-
-Makefiles require that the SILABS_SDKDIR variable point to the
-SimplicityStudio_v4/developer/sdks/gecko_sdk_suite/v2.7 directory, so take
-note of where SimplicityStudio_v4 ended up, if you followed the steps above,
-then it should be stored at /home/user/SimplicityStudio_v4, which is the default
-for SILABS_SDKDIR in the Makefiles.
 
 # Headeredit
 The headeredit tool is needed for embedding metadata into firmware images. The

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A good tool for receiving the output from a serial port is
 [serial-logger](https://github.com/thinnect/serial-logger).
 
 # Embbedded operating system
-The node platform is built around the ARM CMSIS RTOS abstaction layer and
+The node platform is built around the ARM CMSIS RTOS abstraction layer and
 therefore it would not be too complex to support different operating systems,
 however currently only [FreeRTOS](https://github.com/FreeRTOS) is used in
 practice and there may be some direct hooks into the FreeRTOS kernel in the code.

--- a/apps/blink-silabs/Makefile
+++ b/apps/blink-silabs/Makefile
@@ -18,7 +18,7 @@ CFLAGS                  += -ffunction-sections -fdata-sections -ffreestanding -f
 CFLAGS                  += -DconfigUSE_TICKLESS_IDLE=0
 CFLAGS                  += -D__START=main -D__STARTUP_CLEAR_BSS
 CFLAGS                  += -DVTOR_START_LOCATION=$(APP_START)
-LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit
+LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit -specs=nosys.specs
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
@@ -49,7 +49,7 @@ PROGRAM_DEST_ADDR       ?= $(APP_START)
 # distributed with this project and must be installed with Simplicity Studio.
 # The variable needs to point at the subdirectory with the version number, set
 # it in Makefile.private or through the environment.
-SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v4/developer/sdks/gecko_sdk_suite/v2.7
+SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v5/developer/sdks/gecko_sdk_suite/v3.2
 
 # Pull in the developer's private configuration overrides and settings
 -include Makefile.private

--- a/apps/blink-silabs/Makefile
+++ b/apps/blink-silabs/Makefile
@@ -22,6 +22,9 @@ LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
+# The CMSIS RTOS2 wrapper for FreeRTOS now requires this flag to actually import the components 
+CFLAGS                  += -D_RTE_=1
+
 # If set, disables asserts and debugging, enables optimization
 RELEASE_BUILD           ?= 0
 

--- a/apps/dataflash-silabs/Makefile
+++ b/apps/dataflash-silabs/Makefile
@@ -18,7 +18,7 @@ CFLAGS                  += -ffunction-sections -fdata-sections -ffreestanding -f
 CFLAGS                  += -DconfigUSE_TICKLESS_IDLE=0
 CFLAGS                  += -D__START=main -D__STARTUP_CLEAR_BSS
 CFLAGS                  += -DVTOR_START_LOCATION=$(APP_START)
-LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit
+LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit -specs=nosys.specs
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
@@ -49,7 +49,8 @@ PROGRAM_DEST_ADDR       ?= $(APP_START)
 # distributed with this project and must be installed with Simplicity Studio.
 # The variable needs to point at the subdirectory with the version number, set
 # it in Makefile.private or through the environment.
-SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v4/developer/sdks/gecko_sdk_suite/v2.7
+SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v5/developer/sdks/gecko_sdk_suite/v3.2
+
 
 # Pull in the developer's private configuration overrides and settings
 -include Makefile.private

--- a/apps/dataflash-silabs/Makefile
+++ b/apps/dataflash-silabs/Makefile
@@ -22,6 +22,9 @@ LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
+# The CMSIS RTOS2 wrapper for FreeRTOS now requires this flag to actually import the components 
+CFLAGS                  += -D_RTE_=1
+
 # If set, disables asserts and debugging, enables optimization
 RELEASE_BUILD           ?= 0
 

--- a/apps/hello-silabs/Makefile
+++ b/apps/hello-silabs/Makefile
@@ -17,7 +17,7 @@ CFLAGS                  += -Wall -std=c99
 CFLAGS                  += -ffunction-sections -fdata-sections -ffreestanding -fsingle-precision-constant -Wstrict-aliasing=0
 CFLAGS                  += -D__START=main -D__STARTUP_CLEAR_BSS
 CFLAGS                  += -DVTOR_START_LOCATION=$(APP_START)
-LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit
+LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit -specs=nosys.specs
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
@@ -45,7 +45,7 @@ PROGRAM_DEST_ADDR       ?= $(APP_START)
 # distributed with this project and must be installed with Simplicity Studio.
 # The variable needs to point at the subdirectory with the version number, set
 # it in Makefile.private or through the environment.
-SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v4/developer/sdks/gecko_sdk_suite/v2.7
+SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v5/developer/sdks/gecko_sdk_suite/v3.2
 
 # Pull in the developer's private configuration overrides and settings
 -include Makefile.private

--- a/apps/i2c-scan-silabs/Makefile
+++ b/apps/i2c-scan-silabs/Makefile
@@ -18,7 +18,7 @@ CFLAGS                  += -ffunction-sections -fdata-sections -ffreestanding -f
 CFLAGS                  += -DconfigUSE_TICKLESS_IDLE=0
 CFLAGS                  += -D__START=main -D__STARTUP_CLEAR_BSS
 CFLAGS                  += -DVTOR_START_LOCATION=$(APP_START)
-LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit
+LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit -specs=nosys.specs
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
@@ -49,7 +49,7 @@ PROGRAM_DEST_ADDR       ?= $(APP_START)
 # distributed with this project and must be installed with Simplicity Studio.
 # The variable needs to point at the subdirectory with the version number, set
 # it in Makefile.private or through the environment.
-SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v4/developer/sdks/gecko_sdk_suite/v2.7
+SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v5/developer/sdks/gecko_sdk_suite/v3.2
 
 # Pull in the developer's private configuration overrides and settings
 -include Makefile.private

--- a/apps/i2c-scan-silabs/Makefile
+++ b/apps/i2c-scan-silabs/Makefile
@@ -22,6 +22,9 @@ LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
+# The CMSIS RTOS2 wrapper for FreeRTOS now requires this flag to actually import the components 
+CFLAGS                  += -D_RTE_=1
+
 # If set, disables asserts and debugging, enables optimization
 RELEASE_BUILD           ?= 0
 

--- a/apps/radio-count-to-leds-silabs/Makefile
+++ b/apps/radio-count-to-leds-silabs/Makefile
@@ -23,7 +23,7 @@ CFLAGS                  += -ffunction-sections -fdata-sections -ffreestanding -f
 CFLAGS                  += -DconfigUSE_TICKLESS_IDLE=0
 CFLAGS                  += -D__START=main -D__STARTUP_CLEAR_BSS
 CFLAGS                  += -DVTOR_START_LOCATION=$(APP_START)
-LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit
+LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit -specs=nosys.specs
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
@@ -54,7 +54,7 @@ PROGRAM_DEST_ADDR       ?= $(APP_START)
 # distributed with this project and must be installed with Simplicity Studio.
 # The variable needs to point at the subdirectory with the version number, set
 # it in Makefile.private or through the environment.
-SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v4/developer/sdks/gecko_sdk_suite/v2.7
+SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v5/developer/sdks/gecko_sdk_suite/v3.2
 
 # Pull in the developer's private configuration overrides and settings
 -include Makefile.private
@@ -130,7 +130,6 @@ SOURCES += \
     $(SILABS_SDKDIR)/platform/emlib/src/em_timer.c \
     $(SILABS_SDKDIR)/platform/emlib/src/em_wdog.c \
     $(SILABS_SDKDIR)/platform/emdrv/sleep/src/sleep.c \
-    $(SILABS_SDKDIR)/platform/radio/rail_lib/hal/hal_common.c \
     $(NODE_PLATFORM_DIR)/silabs/radio_rtos.c \
     $(NODE_PLATFORM_DIR)/common/radio_seqNum.c \
     $(NODE_PLATFORM_DIR)/common/sys_panic.c \

--- a/apps/radio-count-to-leds-silabs/Makefile
+++ b/apps/radio-count-to-leds-silabs/Makefile
@@ -27,6 +27,9 @@ LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
+# The CMSIS RTOS2 wrapper for FreeRTOS now requires this flag to actually import the components 
+CFLAGS                  += -D_RTE_=1
+
 # If set, disables asserts and debugging, enables optimization
 RELEASE_BUILD           ?= 0
 

--- a/apps/tempsender-silabs/Makefile
+++ b/apps/tempsender-silabs/Makefile
@@ -25,7 +25,7 @@ CFLAGS                  += -ffunction-sections -fdata-sections -ffreestanding -f
 CFLAGS                  += -DconfigUSE_TICKLESS_IDLE=0
 CFLAGS                  += -D__START=main -D__STARTUP_CLEAR_BSS
 CFLAGS                  += -DVTOR_START_LOCATION=$(APP_START)
-LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit
+LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=$(@:.elf=.map),--cref -Wl,--wrap=atexit -specs=nosys.specs
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
@@ -56,7 +56,7 @@ PROGRAM_DEST_ADDR       ?= $(APP_START)
 # distributed with this project and must be installed with Simplicity Studio.
 # The variable needs to point at the subdirectory with the version number, set
 # it in Makefile.private or through the environment.
-SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v4/developer/sdks/gecko_sdk_suite/v2.7
+SILABS_SDKDIR           ?= $(HOME)/SimplicityStudio_v5/developer/sdks/gecko_sdk_suite/v3.2
 
 # Pull in the developer's private configuration overrides and settings
 -include Makefile.private
@@ -139,7 +139,6 @@ SOURCES += \
     $(SILABS_SDKDIR)/platform/emlib/src/em_timer.c \
     $(SILABS_SDKDIR)/platform/emlib/src/em_wdog.c \
     $(SILABS_SDKDIR)/platform/emdrv/sleep/src/sleep.c \
-    $(SILABS_SDKDIR)/platform/radio/rail_lib/hal/hal_common.c \
     $(NODE_PLATFORM_DIR)/silabs/radio_rtos.c \
     $(NODE_PLATFORM_DIR)/common/radio_seqNum.c \
     $(NODE_PLATFORM_DIR)/common/sys_panic.c

--- a/apps/tempsender-silabs/Makefile
+++ b/apps/tempsender-silabs/Makefile
@@ -29,6 +29,9 @@ LDFLAGS                 += -nostartfiles -Wl,--gc-sections -Wl,--relax -Wl,-Map=
 LDLIBS                  += -lgcc -lm
 INCLUDES                += -Xassembler -I$(BUILD_DIR) -I.
 
+# The CMSIS RTOS2 wrapper for FreeRTOS now requires this flag to actually import the components 
+CFLAGS                  += -D_RTE_=1
+
 # If set, disables asserts and debugging, enables optimization
 RELEASE_BUILD           ?= 0
 


### PR DESCRIPTION
- Update from Gecko SDK 2.7.9.0 to 3.2.0.0 (latest as of 06.2021) 
- Update Installation instructions to Simplicity Studio 5, to get latest sdk and also leverage the latest ARM toolchain (`10-2020-q4-major`) that comes with it.
- Tested all apps on Thunderboard 2 and tsb2